### PR TITLE
Refactor: remove data from rails helper

### DIFF
--- a/spec/poros/movie_spec.rb
+++ b/spec/poros/movie_spec.rb
@@ -2,15 +2,36 @@ require 'rails_helper'
 
 RSpec.describe Movie do
   it 'exists' do
+    data = {id: 550,
+            title: "Fight Club",
+            vote_average: 8.4,
+            runtime: 139,
+            overview: "blah",
+            genres: {id: 1, name: 'drama'},
+            poster_path: "/daudhakjf.jpg"
+            }
+
     fight = Movie.new(data)
     expect(fight).to be_an_instance_of(Movie)
   end
 
   it 'has attributes' do
+    data = {id: 550,
+            title: "Fight Club",
+            vote_average: 8.4,
+            runtime: 139,
+            overview: "blah",
+            genres: {id: 1, name: 'drama'},
+            poster_path: "/daudhakjf.jpg"
+            }
+
     fight = Movie.new(data)
     expect(fight.id).to eq(550)
     expect(fight.title).to eq("Fight Club")
     expect(fight.vote_average).to eq(8.4)
-    # expect(fight.runtime).to eq(8.4)
+    expect(fight.runtime).to eq(139)
+    expect(fight.summary).to eq("blah")
+    expect(fight.genres).to eq({id:1, name: 'drama'})
+    expect(fight.poster_path).to eq("/daudhakjf.jpg")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,24 +95,3 @@ VCR.configure do |config|
   config.configure_rspec_metadata!
   config.allow_http_connections_when_no_cassette = true
 end
-
-def data
-  {
-              "adult": false,
-              "backdrop_path": "/xRyINp9KfMLVjRiO5nCsoRDdvvF.jpg",
-              "genre_ids": [
-                  18
-              ],
-              "id": 550,
-              "original_language": "en",
-              "original_title": "Fight Club",
-              "overview": "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy. Their concept catches on, with underground \"fight clubs\" forming in every town, until an eccentric gets in the way and ignites an out-of-control spiral toward oblivion.",
-              "popularity": 60.783,
-              "poster_path": "/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg",
-              "release_date": "1999-10-15",
-              "title": "Fight Club",
-              "video": false,
-              "vote_average": 8.4,
-              "vote_count": 23389
-          }
-end


### PR DESCRIPTION
Refactor to test data for movie poro spec

## Description
Removed the `def data` from the rails_helper and simplified the data variable we are feeding to our movie PORO spec. 

## Motivation and Context
Makes testing more clear/follow a uniform pattern.

## How has this been tested?
Movie PORO spec
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ x] Removed all save_and_open_pages, prys, etc
- [ x] I have fully tested my changes

## Glaring Concerns (if needed)
